### PR TITLE
Remove SKK processing from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,6 @@ install:
 emacs:
 	emacs --batch -f batch-byte-compile ~/.emacs.d/init.el
 
-.PHONY: skk
-skk:
-	curl -o ${HOME}/.eskk/SKK-JISYO.L --create-dirs http://openlab.jp/skk/skk/dic/SKK-JISYO.L
-	touch ${HOME}/.eskk/USER.L
-
 clean:
 	@-$(foreach dotfile, $(DOT_FILES), rm -vrf $(HOME)/$(dotfile);)
 	@-$(foreach configdir, $(REPO_CONFIG_DIRS), rm -vrf $(HOME)/$(configdir);)


### PR DESCRIPTION
MakefileからSKK dictionaryのダウンロード処理（skk target）を削除しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * SKK辞書およびユーザー辞書を取得・作成する処理を削除しました。
  * SKK関連のビルド手順を利用できなくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->